### PR TITLE
Automated CI workflow - fixes #16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, dev ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run:
+        cargo build --verbose
+
+    - name: Setup
+      run: make setup
+
+    - name: Run rust tests
+      run: cargo test --verbose
+
+    - name: Run fork test-suite
+      shell: bash
+      run: |
+          export PATH="$HOME/.wasmtime/bin:$PATH"
+          sh test.sh -v

--- a/makefile
+++ b/makefile
@@ -2,6 +2,11 @@
 main: src/main.rs
 	cargo run -- fork/hello.frk out/hello.wasm
 
+.PHONY: setup
+setup:
+	printf "\x1b[35m%s\x1b[0m" "Installing runtimes"
+	curl https://wasmtime.dev/install.sh -sSf | bash
+
 .PHONY: build
 build: src/main.rs
 	cargo build
@@ -21,4 +26,3 @@ book: book/book.toml
 
 .PHONY: serve
 serve:
-	mdbook serve book --dest-dir ../docs

--- a/test.sh
+++ b/test.sh
@@ -16,14 +16,14 @@ NC='\033[0m'
 # Reading arguments
 verbose=false
 while getopts ":hv" opt; do
-  case ${opt} in
-    h ) # help
-      printf "Usage: tests.sh [-h] [-v]\n"
-      ;;
-    v ) # verbose
-      verbose=true
-      ;;
-  esac
+    case ${opt} in
+        h ) # help
+            printf "Usage: tests.sh [-h] [-v]\n"
+            ;;
+        v ) # verbose
+            verbose=true
+            ;;
+    esac
 done
 
 # Header
@@ -31,12 +31,12 @@ printf "${CYAN}/// Fork integration tests ///${NC}\n"
 printf "Using $RUNTIME as runtime\n\n"
 
 if ! [ -x "$(command -v $RUNTIME)" ]; then
-  echo -e "${RED}Error: $RUNTIME is not installed${NC}" >&2
-  exit 1
+    printf "${RED}Error: $RUNTIME is not installed${NC}\n" >&2
+    exit 1
 fi
 
 if [ ! -f "$FORK" ]; then
-    echo "Could not find fork"
+    printf "Could not find fork"
     exit 1
 fi
 


### PR DESCRIPTION
fixes #16

**Description**
This PR introduces a new make target, `make setup`. This target can setup the different runtimes we might need to test.
This should do for now.