### PR TITLE
Add support for multi-files in ErrorHandler - fixes #21

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -11,7 +11,7 @@ pub use tokens::*;
 pub fn get_ast<'a, 'b>(code: &str, error_handler: &'b mut ErrorHandler<'a>) -> ast::Program {
     println!("\n/// Scanning ///\n");
 
-    let mut scanner = scan::Scanner::new(code, error_handler);
+    let mut scanner = scan::Scanner::new(code, 0, error_handler);
     let tokens = scanner.scan();
 
     for token in tokens.iter() {

--- a/src/ast/scan.rs
+++ b/src/ast/scan.rs
@@ -6,6 +6,7 @@ const RADIX: u32 = 10;
 
 pub struct Scanner<'a, 'b> {
     err: &'b mut ErrorHandler<'a>,
+    f_id: u16,
     code: Vec<char>,
     start: usize,
     current: usize,
@@ -15,7 +16,7 @@ pub struct Scanner<'a, 'b> {
 }
 
 impl<'a, 'b> Scanner<'a, 'b> {
-    pub fn new(code: &str, error_handler: &'b mut ErrorHandler<'a>) -> Scanner<'a, 'b> {
+    pub fn new(code: &str, f_id: u16, error_handler: &'b mut ErrorHandler<'a>) -> Scanner<'a, 'b> {
         let keywords: HashMap<String, TokenType> = [
             (String::from("let"), TokenType::Let),
             (String::from("var"), TokenType::Var),
@@ -34,6 +35,7 @@ impl<'a, 'b> Scanner<'a, 'b> {
 
         Scanner {
             err: error_handler,
+            f_id: f_id,
             code: code.chars().collect(), // TODO: remove this copy
             start: 0,
             current: 0,
@@ -177,6 +179,7 @@ impl<'a, 'b> Scanner<'a, 'b> {
             loc: Location {
                 pos: self.start as u32,
                 len: (self.current - self.start) as u32,
+                f_id: self.f_id,
             },
         };
         self.check_stmt_ender(&token);
@@ -187,6 +190,7 @@ impl<'a, 'b> Scanner<'a, 'b> {
         Location {
             pos: self.start as u32,
             len: (self.current - self.start) as u32,
+            f_id: self.f_id,
         }
     }
 

--- a/src/error/errors.rs
+++ b/src/error/errors.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 pub struct Location {
     pub pos: u32,
     pub len: u32,
+    pub f_id: u16,
 }
 
 pub struct Error {
@@ -45,15 +46,28 @@ impl PartialEq for Error {
 }
 
 impl Location {
-    // Use to create empty location when needed
+    // Used to create empty location when needed
     pub fn dummy() -> Location {
-        Location { pos: 0, len: 0 }
+        Location {
+            pos: 0,
+            len: 0,
+            f_id: 0,
+        }
     }
 
+    /// Return a new `Location` spanning `self` to `other` (ordering does not matter).
     pub fn merge(self, other: Location) -> Location {
+        if self.f_id != other.f_id {
+            println!("Internal error: merging two locations with distinct f_id");
+            std::process::exit(1);
+        }
         let pos = std::cmp::min(self.pos, other.pos);
         let len = std::cmp::max(self.pos + self.len, other.pos + other.len) - pos;
-        Location { pos: pos, len: len }
+        Location {
+            pos: pos,
+            len: len,
+            f_id: self.f_id,
+        }
     }
 }
 
@@ -63,12 +77,38 @@ mod tests {
 
     #[test]
     fn locations() {
-        let loc_1 = Location { pos: 10, len: 5 };
-        let loc_2 = Location { pos: 12, len: 8 };
-        let loc_3 = Location { pos: 11, len: 3 };
+        let loc_1 = Location {
+            pos: 10,
+            len: 5,
+            f_id: 0,
+        };
+        let loc_2 = Location {
+            pos: 12,
+            len: 8,
+            f_id: 0,
+        };
+        let loc_3 = Location {
+            pos: 11,
+            len: 3,
+            f_id: 0,
+        };
 
-        assert_eq!(loc_1.merge(loc_2), Location { pos: 10, len: 10 });
-        assert_eq!(loc_2.merge(loc_3), Location { pos: 11, len: 9 });
+        assert_eq!(
+            loc_1.merge(loc_2),
+            Location {
+                pos: 10,
+                len: 10,
+                f_id: 0
+            }
+        );
+        assert_eq!(
+            loc_2.merge(loc_3),
+            Location {
+                pos: 11,
+                len: 9,
+                f_id: 0
+            }
+        );
         assert_eq!(loc_1.merge(loc_3), loc_1);
         assert_eq!(loc_1.merge(loc_2), loc_2.merge(loc_1));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn compile(code: String, output_path: &str) {
-    let mut error_handler = error::ErrorHandler::new(&code);
+    let mut error_handler = error::ErrorHandler::new(&code, 0);
     let ast_program = ast::get_ast(&code, &mut error_handler);
     let mir_program = mir::to_mir(ast_program, &mut error_handler);
     let binary = wasm::to_wasm(mir_program, &mut error_handler);


### PR DESCRIPTION
- Add file ID to Location
- Throw error when merging Locations with distinct IDs
- Handle multi-files supports in ErrorHandler
- Add `merge` method to ErrorHander

This fixes #21.