### PR TITLE
Extend AST pretty printing to support packages - fixes #35

### DIFF
--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -132,6 +132,31 @@ pub struct Block {
 impl fmt::Display for Program {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut program = String::from("");
+        // Package
+        program.push_str(&format!("packge \"{}\";\n\n", self.package.path));
+        // Use
+        for is_used in &self.used {
+            program.push_str(&format!("use \"{}\"", is_used.path));
+            if let Some(ref alias) = is_used.alias {
+                program.push_str(&format!(" as {}", alias));
+            }
+            program.push_str(";\n");
+        }
+        if self.used.len() > 0 {
+            program.push_str("\n");
+        }
+        // Expose
+        for expose in &self.exposed {
+            program.push_str(&format!("expose {}", expose.ident));
+            if let Some(ref alias) = expose.alias {
+                program.push_str(&format!(" as {}", alias));
+            }
+            program.push_str(";\n");
+        }
+        if self.exposed.len() > 0 {
+            program.push_str("\n");
+        }
+        // Fun
         for stmt in &self.funs {
             program.push_str(&format!("{}\n", stmt));
         }
@@ -141,7 +166,7 @@ impl fmt::Display for Program {
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let prefix = if self.exported { "export " } else { "" };
+        let prefix = if self.exported { "pub " } else { "" };
         let params = self
             .params
             .iter()


### PR DESCRIPTION
Support `package`, `use` and `expose` declarations. Fixes #35.

Pretty printing example:

```
packge "hello";

use "std/math" as math;
use "std/strings";

expose Main as _main;

pub Main(a i32, b i32) i32 {
    if (b == 0) {
        return 1;
    };
    let n = b;
    let x = a;
    let acc = 1;
    while (n > 1) {
        if ((n % 2) == 1) {
            acc = (acc * x);
        };
        x = (x * x);
        n = (n / 2);
    };
    return (x * acc);
};
```