### PR TITLE
Feature/package support - fixes  #40

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8,10 +8,10 @@ mod tokens;
 pub use ast::*;
 pub use tokens::*;
 
-pub fn get_ast(code: &str, error_handler: &mut ErrorHandler) -> ast::Program {
+pub fn get_ast(f_id: u16, error_handler: &mut ErrorHandler) -> ast::Program {
     println!("\n/// Scanning ///\n");
 
-    let mut scanner = scan::Scanner::new(code, 0, error_handler);
+    let mut scanner = scan::Scanner::new(f_id, error_handler);
     let tokens = scanner.scan();
 
     for token in tokens.iter() {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8,7 +8,7 @@ mod tokens;
 pub use ast::*;
 pub use tokens::*;
 
-pub fn get_ast<'a, 'b>(code: &str, error_handler: &'b mut ErrorHandler<'a>) -> ast::Program {
+pub fn get_ast(code: &str, error_handler: &mut ErrorHandler) -> ast::Program {
     println!("\n/// Scanning ///\n");
 
     let mut scanner = scan::Scanner::new(code, 0, error_handler);

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -2,16 +2,16 @@ use super::ast::*;
 use super::tokens::{Token, TokenType};
 use crate::error::{ErrorHandler, Location};
 
-pub struct Parser<'a, 'b> {
-    err: &'b mut ErrorHandler<'a>,
+pub struct Parser<'a> {
+    err: &'a mut ErrorHandler,
     tokens: Vec<Token>,
     current: usize,
 }
 
 /// Works on a list of tokens and converts it into an Abstract Syntax Tree,
 /// following the grammar of the language (defined in 'grammar.md')
-impl<'a, 'b> Parser<'a, 'b> {
-    pub fn new(tokens: Vec<Token>, error_handler: &'b mut ErrorHandler<'a>) -> Parser<'a, 'b> {
+impl<'a> Parser<'a> {
+    pub fn new(tokens: Vec<Token>, error_handler: &mut ErrorHandler) -> Parser {
         Parser {
             err: error_handler,
             tokens: tokens,

--- a/src/ast/scan.rs
+++ b/src/ast/scan.rs
@@ -6,8 +6,8 @@ const RADIX: u32 = 10;
 
 /// Stores source code as a vector of chars and provides functions to convert
 /// the source code to a list of tokens.
-pub struct Scanner<'a, 'b> {
-    err: &'b mut ErrorHandler<'a>,
+pub struct Scanner<'a> {
+    err: &'a mut ErrorHandler,
     f_id: u16,
     code: Vec<char>,
     start: usize,
@@ -17,8 +17,8 @@ pub struct Scanner<'a, 'b> {
     parenthesis_count: i32,
 }
 
-impl<'a, 'b> Scanner<'a, 'b> {
-    pub fn new(code: &str, f_id: u16, error_handler: &'b mut ErrorHandler<'a>) -> Scanner<'a, 'b> {
+impl<'a> Scanner<'a> {
+    pub fn new(code: &str, f_id: u16, error_handler: &'a mut ErrorHandler) -> Scanner<'a> {
         let keywords: HashMap<String, TokenType> = [
             (String::from("as"), TokenType::As),
             (String::from("else"), TokenType::Else),

--- a/src/ast/scan.rs
+++ b/src/ast/scan.rs
@@ -18,7 +18,8 @@ pub struct Scanner<'a> {
 }
 
 impl<'a> Scanner<'a> {
-    pub fn new(code: &str, f_id: u16, error_handler: &'a mut ErrorHandler) -> Scanner<'a> {
+    // f_id MUST exist, no check performed.
+    pub fn new(f_id: u16, error_handler: &'a mut ErrorHandler) -> Scanner<'a> {
         let keywords: HashMap<String, TokenType> = [
             (String::from("as"), TokenType::As),
             (String::from("else"), TokenType::Else),
@@ -38,11 +39,14 @@ impl<'a> Scanner<'a> {
         .iter()
         .cloned()
         .collect();
+        
+        // f_id MUST exist
+        let code = error_handler.get_file(f_id).unwrap();
 
         Scanner {
+            code: code.chars().collect(), // TODO: remove this copy
             err: error_handler,
             f_id: f_id,
-            code: code.chars().collect(), // TODO: remove this copy
             start: 0,
             current: 0,
             keywords: keywords,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -5,6 +5,16 @@ use crate::error;
 use crate::mir;
 use crate::wasm;
 
+/// Exit the program and return an error code 64 (malformed entry)
+#[macro_use]
+macro_rules! exit {
+    () => {
+        std::process::exit(64);
+    };
+}
+
+/// The Driver is responsible for orchestrating the compilation process, that is resolving
+/// packages, starting each phases of the pipeline and mergind code at appropriate time.
 pub struct Driver {
     input: String,
     output: String,
@@ -22,17 +32,12 @@ impl Driver {
 
     /// Starts the compilation and exit.
     pub fn compile(&mut self) {
-        // let ast_program = ast::get_ast(&code, &mut error_handler);
-        // let mut error_handler = error::ErrorHandler::new(&code, 0);
-        // let mir_program = mir::to_mir(ast_program, &mut error_handler);
-        // let binary = wasm::to_wasm(mir_program, &mut error_handler);
-
-
-        let (pkg_ast, mut error_handler) = if let Ok(res) = self.get_package_ast(&self.input.clone()) {
-            res
-        } else {
-            std::process::exit(64);
-        };
+        let (pkg_ast, mut error_handler) =
+            if let Ok(res) = self.get_package_ast(&self.input.clone()) {
+                res
+            } else {
+                exit!();
+            };
         let mir_program = mir::to_mir(pkg_ast, &mut error_handler);
         let binary = wasm::to_wasm(mir_program, &mut error_handler);
 
@@ -44,13 +49,14 @@ impl Driver {
         std::process::exit(0);
     }
 
+    /// Return the AST of the package located at the given path.
     fn get_package_ast(&mut self, path: &str) -> Result<(ast::Program, error::ErrorHandler), ()> {
         // Resolve path
-        let paths = match self.resolve_path(path) {
-            Ok(paths) => paths,
+        let (paths, is_unique_file) = match self.resolve_path(path) {
+            Ok(result) => result,
             Err(err) => {
                 println!("{}", &err);
-                std::process::exit(64);
+                exit!();
             }
         };
         if paths.len() == 0 {
@@ -69,7 +75,6 @@ impl Driver {
         }
         for (code, f_id) in files.into_iter() {
             let mut error_handler = error::ErrorHandler::new(code, f_id);
-            let code = error_handler.get_file(f_id).unwrap();
             let ast_program = ast::get_ast(f_id, &mut error_handler);
             ast_programs.push((ast_program, error_handler));
         }
@@ -78,35 +83,116 @@ impl Driver {
         let mut funs = Vec::new();
         let mut exposed = Vec::new();
         let mut used = Vec::new();
+        let mut package: Option<(String, error::ErrorHandler)> = None;
 
-        let (ast_program, mut error_handler) = ast_programs.pop().unwrap();
-        funs.extend(ast_program.funs);
-        exposed.extend(ast_program.exposed);
-        used.extend(ast_program.used);
-
-        let package = ast_program.package;
-
+        // Iterate over ast_program of all fork files in the folder
         for (ast, err_handler) in ast_programs {
-            funs.extend(ast.funs);
-            exposed.extend(ast.exposed);
-            used.extend(ast.used);
-            error_handler._merge(err_handler);
+            let package_name = ast.package.path;
+            if let Some((ref name, ref mut error_handler)) = package {
+                if &package_name == name {
+                    // Extend AST package
+                    error_handler.merge(err_handler);
+                    funs.extend(ast.funs);
+                    exposed.extend(ast.exposed);
+                    used.extend(ast.used);
+                } else {
+                    if is_orphan(&package_name) {
+                        if !validate_orphan_file(&package_name) {
+                            println!(
+                                "Warning: malformed orphan file name: '{}' at '{}'.",
+                                &package_name, path
+                            );
+                        }
+                    } else if is_single_file_package(&package_name) {
+                        if let Some((host_package, guest_package)) =
+                            validate_single_file_package(&package_name)
+                        {
+                            if &host_package != name {
+                                println!("Error: malformed single file package '{}' at '{}', host package should be '{}/{}'.", &package_name, path, name, guest_package);
+                                exit!();
+                            }
+                        } else {
+                            println!(
+                                "Error: malformed single file package name '{}' at '{}'.",
+                                &package_name, path
+                            );
+                            exit!();
+                        }
+                    } else {
+                        println!(
+                            "Error: multiple packages defined in the same directory at '{}'.",
+                            path
+                        );
+                        exit!()
+                    }
+                }
+            } else {
+                if is_single_file_package(&package_name) {
+                    if let Some(_) = validate_single_file_package(&package_name) {
+                        if !is_unique_file {
+                            continue;
+                        }
+                    // else add package to AST
+                    } else {
+                        println!(
+                            "Error: malformed single file package '{}' at '{}'.",
+                            &package_name, path
+                        );
+                        exit!();
+                    }
+                } else if is_orphan(&package_name) {
+                    if validate_orphan_file(&package_name) {
+                        if !is_unique_file {
+                            continue;
+                        }
+                    } else {
+                        println!(
+                            "Error: malformed orphan file name: '{}' at '{}'.",
+                            &package_name, path
+                        );
+                        exit!();
+                    }
+                } else {
+                    if !validate_package(&package_name) {
+                        println!("Package name '{}' is malformed. A package name must contain only lower case characters or underscores '_'.", package_name);
+                        continue;
+                    } else if is_unique_file {
+                        // Unique belonging to a well formed package, scan the whole directory for
+                        // other files that may belong to that same package.
+                        return self.get_package_ast(&get_directory_path(path));
+                    }
+                }
+                // Well formed package name
+                package = Some((package_name, err_handler));
+                funs.extend(ast.funs);
+                exposed.extend(ast.exposed);
+                used.extend(ast.used);
+            }
         }
 
-        return Ok((
-            ast::Program {
-                package: package,
-                exposed: exposed,
-                used: used,
-                funs: funs,
-            },
-            error_handler,
-        ));
+        if let Some((name, error_handler)) = package {
+            let package = ast::Package {
+                path: name,
+                loc: error::Location::dummy(),
+            };
+            Ok((
+                ast::Program {
+                    package: package,
+                    exposed: exposed,
+                    used: used,
+                    funs: funs,
+                },
+                error_handler,
+            ))
+        } else {
+            println!("Could not find a valid package at '{}'.", path);
+            Err(())
+        }
     }
 
-    /// Returns a list of path to files to be parsed.
-    /// In case of success, return at least one path.
-    fn resolve_path(&self, path: &str) -> Result<Vec<String>, String> {
+    /// Returns a list of path to files to be parsed and a flag indicating if the path point at a
+    /// file. In case of success, return at least one path.
+    fn resolve_path(&self, path: &str) -> Result<(Vec<String>, bool), String> {
         let file_info = if let Ok(f) = fs::metadata(&path) {
             f
         } else {
@@ -132,7 +218,7 @@ impl Driver {
                 if paths.len() == 0 {
                     Err(format!("Could not find any fork file (.frk) in '{}'", path))
                 } else {
-                    Ok(paths)
+                    Ok((paths, false))
                 }
             } else {
                 Err(String::from(""))
@@ -144,7 +230,7 @@ impl Driver {
                 return Err(String::from("Could not read file extension"));
             };
             if extension.eq("frk") {
-                Ok(vec![path.to_string()])
+                Ok((vec![path.to_string()], true))
             } else {
                 Err(format!("Invalid file extension '{}'.", &extension))
             }
@@ -154,7 +240,7 @@ impl Driver {
     }
 }
 
-/// Return the file extension of a given path, if applicable.
+/// Returns the file extension of a given path, if applicable.
 fn get_extension(path: &str) -> Option<String> {
     match std::path::Path::new(path).extension() {
         Some(ext) => match ext.to_str() {
@@ -162,5 +248,166 @@ fn get_extension(path: &str) -> Option<String> {
             None => None,
         },
         None => None,
+    }
+}
+
+fn get_directory_path(path: &str) -> String {
+    let path = path.split('/').map(|s| s.to_string()).collect::<Vec<String>>();
+    if path.len() <= 1 {
+        String::from(".")
+    } else {
+        path[..path.len() -1].join("/")
+    }
+}
+
+/// Returns `true` if the package looks like an orphan file (i.e. it starts with an `#`)
+fn is_orphan(package_name: &str) -> bool {
+    if let Some(c) = package_name.chars().next() {
+        c == '#'
+    } else {
+        false
+    }
+}
+
+/// Returns `true` if the package looks like a single file package
+fn is_single_file_package(package_name: &str) -> bool {
+    // A single file package MUST contain a `/`, and is the only
+    // type of package allowed to.
+    package_name.chars().find(|c| *c == '/').is_some()
+}
+
+/// Returns `true` if the package name is correct, that is:
+/// - It contrains only lower case characters and underscores
+/// - It starts with a lower case character
+fn validate_package(package_name: &str) -> bool {
+    let mut is_first = true;
+    for c in package_name.chars() {
+        if c == '_' && !is_first {
+            continue;
+        } else if !c.is_alphabetic() {
+            return false;
+        } else if !c.is_lowercase() {
+            return false;
+        }
+        is_first = false;
+    }
+    true
+}
+
+/// Returns `true` if the package name is a valid orphan file, that is:
+/// - It starts with `#`
+/// - It is followed by  a valid package name
+fn validate_orphan_file(package_name: &str) -> bool {
+    match package_name.chars().next() {
+        Some('#') => true,
+        _ => return false,
+    };
+
+    validate_package(&package_name[1..])
+}
+
+/// Returns an option containing the host package name (the main package of the directory) and the
+/// single file package name if the single file package name is well formad, that is:
+/// - It starts with the host package name (a valid package name)
+/// - Is followed by a a slash `/`
+/// - Itself followed by the single file package name (a valid package name)
+fn validate_single_file_package(package_name: &str) -> Option<(String, String)> {
+    let mut parts = package_name.split('/');
+    let host_package = if let Some(host_package) = parts.next() {
+        host_package.to_string()
+    } else {
+        return None;
+    };
+    let single_file_package = if let Some(single_file_package) = parts.next() {
+        single_file_package.to_string()
+    } else {
+        return None;
+    };
+    if parts.next() == None
+        && validate_package(&host_package)
+        && validate_package(&single_file_package)
+    {
+        Some((host_package, single_file_package))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test `get_extension`
+    fn extension() {
+        assert_eq!(
+            get_extension("greeting/hello.frk"),
+            Some(String::from("frk"))
+        );
+        assert_eq!(get_extension("hello.frk"), Some(String::from("frk")));
+        assert_eq!(get_extension("hello"), None);
+    }
+
+    #[test]
+    /// Test `is_orphan`
+    fn orphan() {
+        assert_eq!(is_orphan("#orphan"), true);
+        assert_eq!(is_orphan("orphan"), false);
+        assert_eq!(is_orphan("trap/#orphan"), false);
+        assert_eq!(is_orphan(""), false);
+    }
+
+    #[test]
+    /// Test `is_single_file_package`
+    fn single_file_package() {
+        assert_eq!(is_single_file_package("greeting/hello"), true);
+        assert_eq!(is_single_file_package("greeting"), false);
+        assert_eq!(is_single_file_package("#greeting"), false);
+        assert_eq!(is_single_file_package(""), false);
+    }
+
+    #[test]
+    // test `validate_package`
+    fn package_name() {
+        assert!(validate_package("greeting"));
+        assert!(validate_package("hello_world"));
+        assert!(!validate_package("greeting/hello"));
+        assert!(!validate_package("Greeting"));
+        assert!(!validate_package("_greeting"));
+        assert!(!validate_package("#greeting"));
+    }
+
+    #[test]
+    // test `validate_orphan_file`
+    fn orphan_file_name() {
+        assert!(validate_orphan_file("#greeting"));
+        assert!(validate_orphan_file("#greeting_world"));
+        assert!(!validate_orphan_file("#greeting/hello"));
+        assert!(!validate_orphan_file("greeting"));
+        assert!(!validate_orphan_file("#_greeting"));
+    }
+
+    #[test]
+    // test `validate_single_file_package`
+    fn single_file_package_name() {
+        assert_eq!(
+            validate_single_file_package("greeting/hello"),
+            Some((String::from("greeting"), String::from("hello")))
+        );
+        assert_eq!(
+            validate_single_file_package("greeting_world/hello_world"),
+            Some((String::from("greeting_world"), String::from("hello_world")))
+        );
+        assert_eq!(validate_single_file_package("#greeting/world"), None);
+        assert_eq!(validate_single_file_package("greeting/#world"), None);
+        assert_eq!(validate_single_file_package("greeting/world/hello"), None);
+    }
+
+    #[test]
+    // test `get_directory_path`
+    fn directory_path() {
+        assert_eq!(&get_directory_path("/home/ubuntu/fork/hello.frk"), "/home/ubuntu/fork");
+        assert_eq!(&get_directory_path("fork/hello.fork"), "fork");
+        assert_eq!(&get_directory_path("hello.frk"), ".");
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,166 @@
+use std::fs;
+
+use crate::ast;
+use crate::error;
+use crate::mir;
+use crate::wasm;
+
+pub struct Driver {
+    input: String,
+    output: String,
+    file_id: u16,
+}
+
+impl Driver {
+    pub fn new(input: String, output: String) -> Driver {
+        Driver {
+            input: input,
+            output: output,
+            file_id: 0,
+        }
+    }
+
+    /// Starts the compilation and exit.
+    pub fn compile(&mut self) {
+        // let ast_program = ast::get_ast(&code, &mut error_handler);
+        // let mut error_handler = error::ErrorHandler::new(&code, 0);
+        // let mir_program = mir::to_mir(ast_program, &mut error_handler);
+        // let binary = wasm::to_wasm(mir_program, &mut error_handler);
+
+
+        let (pkg_ast, mut error_handler) = if let Ok(res) = self.get_package_ast(&self.input.clone()) {
+            res
+        } else {
+            std::process::exit(64);
+        };
+        let mir_program = mir::to_mir(pkg_ast, &mut error_handler);
+        let binary = wasm::to_wasm(mir_program, &mut error_handler);
+
+        match fs::write(&self.output, binary) {
+            Ok(_) => (),
+            Err(e) => println!("{}", e),
+        }
+
+        std::process::exit(0);
+    }
+
+    fn get_package_ast(&mut self, path: &str) -> Result<(ast::Program, error::ErrorHandler), ()> {
+        // Resolve path
+        let paths = match self.resolve_path(path) {
+            Ok(paths) => paths,
+            Err(err) => {
+                println!("{}", &err);
+                std::process::exit(64);
+            }
+        };
+        if paths.len() == 0 {
+            println!("Internal error: no file to compile.");
+            return Err(());
+        }
+
+        // Build package ASTs
+        let mut ast_programs = Vec::new();
+        let mut files = Vec::new();
+        for path in paths {
+            let f_id = self.file_id;
+            self.file_id += 1;
+            let code = fs::read_to_string(&path).expect("Internal error: invalid path.");
+            files.push((code, f_id));
+        }
+        for (code, f_id) in files.into_iter() {
+            let mut error_handler = error::ErrorHandler::new(code, f_id);
+            let code = error_handler.get_file(f_id).unwrap();
+            let ast_program = ast::get_ast(f_id, &mut error_handler);
+            ast_programs.push((ast_program, error_handler));
+        }
+
+        // Merge package ASTs
+        let mut funs = Vec::new();
+        let mut exposed = Vec::new();
+        let mut used = Vec::new();
+
+        let (ast_program, mut error_handler) = ast_programs.pop().unwrap();
+        funs.extend(ast_program.funs);
+        exposed.extend(ast_program.exposed);
+        used.extend(ast_program.used);
+
+        let package = ast_program.package;
+
+        for (ast, err_handler) in ast_programs {
+            funs.extend(ast.funs);
+            exposed.extend(ast.exposed);
+            used.extend(ast.used);
+            error_handler._merge(err_handler);
+        }
+
+        return Ok((
+            ast::Program {
+                package: package,
+                exposed: exposed,
+                used: used,
+                funs: funs,
+            },
+            error_handler,
+        ));
+    }
+
+    /// Returns a list of path to files to be parsed.
+    /// In case of success, return at least one path.
+    fn resolve_path(&self, path: &str) -> Result<Vec<String>, String> {
+        let file_info = if let Ok(f) = fs::metadata(&path) {
+            f
+        } else {
+            return Err(format!("Path '{}' does not exist.", path));
+        };
+        if file_info.is_dir() {
+            if let Ok(dir) = fs::read_dir(path) {
+                let mut paths = Vec::new();
+                for entry in dir {
+                    if let Ok(entry) = entry {
+                        let path = if let Some(path) = entry.path().to_str() {
+                            path.to_string()
+                        } else {
+                            continue;
+                        };
+                        if let Some(ext) = get_extension(&path) {
+                            if ext.eq("frk") {
+                                paths.push(path);
+                            }
+                        }
+                    }
+                }
+                if paths.len() == 0 {
+                    Err(format!("Could not find any fork file (.frk) in '{}'", path))
+                } else {
+                    Ok(paths)
+                }
+            } else {
+                Err(String::from(""))
+            }
+        } else if file_info.is_file() {
+            let extension = if let Some(ext) = get_extension(path) {
+                ext
+            } else {
+                return Err(String::from("Could not read file extension"));
+            };
+            if extension.eq("frk") {
+                Ok(vec![path.to_string()])
+            } else {
+                Err(format!("Invalid file extension '{}'.", &extension))
+            }
+        } else {
+            Err(format!("{}' is neither a file nor a directory.", path))
+        }
+    }
+}
+
+/// Return the file extension of a given path, if applicable.
+fn get_extension(path: &str) -> Option<String> {
+    match std::path::Path::new(path).extension() {
+        Some(ext) => match ext.to_str() {
+            Some(ext) => Some(ext.to_string()),
+            None => None,
+        },
+        None => None,
+    }
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -41,12 +41,14 @@ impl Driver {
         let mir_program = mir::to_mir(pkg_ast, &mut error_handler);
         let binary = wasm::to_wasm(mir_program, &mut error_handler);
 
+        // Write down compiled code
         match fs::write(&self.output, binary) {
-            Ok(_) => (),
-            Err(e) => println!("{}", e),
+            Ok(_) => std::process::exit(0),
+            Err(e) => {
+                println!("{}", e);
+                exit!();
+            }
         }
-
-        std::process::exit(0);
     }
 
     /// Return the AST of the package located at the given path.
@@ -251,6 +253,7 @@ fn get_extension(path: &str) -> Option<String> {
     }
 }
 
+/// Returns the path of the directory containing a given file. Path **MUST** point to a file.
 fn get_directory_path(path: &str) -> String {
     let path = path.split('/').map(|s| s.to_string()).collect::<Vec<String>>();
     if path.len() <= 1 {

--- a/src/error/handler.rs
+++ b/src/error/handler.rs
@@ -16,13 +16,22 @@ pub struct ErrorHandler {
 /// Each file should be attributed to a single ErrorHandler. ErrorHandlers can be
 /// merged as needed when proceeding through the pipeline.
 impl ErrorHandler {
-    pub fn new(code: String, f_id: u16) -> ErrorHandler {
+    pub fn new<'a>(code: String, f_id: u16) -> ErrorHandler {
         let mut codes = HashMap::new();
         codes.insert(f_id, code);
         ErrorHandler {
             has_error: false,
             errors: Vec::new(),
             codes: codes,
+        }
+    }
+
+    /// Returns a file owned by the ErrorHandler.
+    pub fn get_file(&self, f_id: u16) -> Option<&str> {
+        if let Some(s) = self.codes.get(&f_id) {
+            Some(&*s)
+        } else {
+            None
         }
     }
 

--- a/src/error/handler.rs
+++ b/src/error/handler.rs
@@ -81,7 +81,7 @@ impl ErrorHandler {
     }
 
     /// Merge another ErrorHandler into self, taking ownership of its errors.
-    pub fn _merge(&mut self, other: ErrorHandler) {
+    pub fn merge(&mut self, other: ErrorHandler) {
         self.has_error = self.has_error || other.has_error;
         self.errors.extend(other.errors);
 

--- a/src/error/handler.rs
+++ b/src/error/handler.rs
@@ -6,17 +6,17 @@ const MAGENTA: &'static str = "\x1B[35m";
 const BOLD: &'static str = "\x1B[1m";
 const END: &'static str = "\x1B[0m";
 
-pub struct ErrorHandler<'a> {
+pub struct ErrorHandler {
     has_error: bool,
     errors: Vec<Error>,
-    codes: HashMap<u16, &'a str>,
+    codes: HashMap<u16, String>,
 }
 
 /// Store errors encountered during compilation and generate a report on demand.
 /// Each file should be attributed to a single ErrorHandler. ErrorHandlers can be
 /// merged as needed when proceeding through the pipeline.
-impl<'a> ErrorHandler<'a> {
-    pub fn new(code: &str, f_id: u16) -> ErrorHandler {
+impl ErrorHandler {
+    pub fn new(code: String, f_id: u16) -> ErrorHandler {
         let mut codes = HashMap::new();
         codes.insert(f_id, code);
         ErrorHandler {
@@ -72,7 +72,7 @@ impl<'a> ErrorHandler<'a> {
     }
 
     /// Merge another ErrorHandler into self, taking ownership of its errors.
-    pub fn _merge(&mut self, other: ErrorHandler<'a>) {
+    pub fn _merge(&mut self, other: ErrorHandler) {
         self.has_error = self.has_error || other.has_error;
         self.errors.extend(other.errors);
 
@@ -136,7 +136,7 @@ impl<'a> ErrorHandler<'a> {
 
     /// Pretty print errors with code context.
     /// All errors **must** have a location corresponding to `code`.
-    fn print_errors_with_loc(&self, code: &'a str, mut errors: Vec<&Error>) {
+    fn print_errors_with_loc(&self, code: &str, mut errors: Vec<&Error>) {
         // Sort errors by locations.
         errors.sort_unstable();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod ast;
 mod error;
 mod mir;
 mod wasm;
+mod driver;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -15,19 +16,11 @@ fn main() {
         println!("Usage: fork <file> [out]");
         std::process::exit(64);
     }
-    let code = fs::read_to_string(&args[1]).expect("File not found");
-    compile(code, output_path);
+    // let code = fs::read_to_string(&args[1]).expect("File not found");
+    compile(args[1].clone(), output_path.to_string());
 }
 
-fn compile(code: String, output_path: &str) {
-    let mut error_handler = error::ErrorHandler::new(&code, 0);
-    let ast_program = ast::get_ast(&code, &mut error_handler);
-    let mir_program = mir::to_mir(ast_program, &mut error_handler);
-    let binary = wasm::to_wasm(mir_program, &mut error_handler);
-
-    match fs::write(output_path, binary) {
-        Ok(_) => (),
-        Err(e) => println!("{}", e),
-    }
-    std::process::exit(0);
+fn compile(input_path: String, output_path: String) {
+    let mut driver = driver::Driver::new(input_path, output_path);
+    driver.compile();
 }

--- a/src/mir/ast_to_mir.rs
+++ b/src/mir/ast_to_mir.rs
@@ -37,12 +37,12 @@ impl State {
     }
 }
 
-pub struct MIRProducer<'a, 'b> {
-    err: &'b mut ErrorHandler<'a>,
+pub struct MIRProducer<'a> {
+    err: &'a mut ErrorHandler,
 }
 
-impl<'a, 'b> MIRProducer<'a, 'b> {
-    pub fn new(error_handler: &'b mut ErrorHandler<'a>) -> MIRProducer<'a, 'b> {
+impl<'a> MIRProducer<'a> {
+    pub fn new(error_handler: &mut ErrorHandler) -> MIRProducer {
         MIRProducer { err: error_handler }
     }
 

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -23,9 +23,9 @@ pub struct TypedProgram {
 
 pub use mir::Program;
 
-pub fn to_mir<'a, 'b>(
+pub fn to_mir<'a>(
     ast_program: ast::Program,
-    error_handler: &'b mut ErrorHandler<'a>,
+    error_handler: &mut ErrorHandler,
 ) -> mir::Program {
     let mut name_resolver = resolver::NameResolver::new(error_handler);
     let program = name_resolver.resolve(ast_program);

--- a/src/mir/resolver.rs
+++ b/src/mir/resolver.rs
@@ -73,12 +73,12 @@ impl State {
     }
 }
 
-pub struct NameResolver<'a, 'b> {
-    err: &'b mut ErrorHandler<'a>,
+pub struct NameResolver<'a> {
+    err: &'a mut ErrorHandler,
 }
 
-impl<'a, 'b> NameResolver<'a, 'b> {
-    pub fn new(error_handler: &'b mut ErrorHandler<'a>) -> NameResolver<'a, 'b> {
+impl<'a> NameResolver<'a> {
+    pub fn new(error_handler: &mut ErrorHandler) -> NameResolver {
         NameResolver { err: error_handler }
     }
 

--- a/src/mir/type_check.rs
+++ b/src/mir/type_check.rs
@@ -11,12 +11,12 @@ enum Progress {
     Error,
 }
 
-pub struct TypeChecker<'a, 'b> {
-    err: &'b mut ErrorHandler<'a>,
+pub struct TypeChecker<'a> {
+    err: &'a mut ErrorHandler,
 }
 
-impl<'a, 'b> TypeChecker<'a, 'b> {
-    pub fn new(error_handler: &'b mut ErrorHandler<'a>) -> TypeChecker<'a, 'b> {
+impl<'a> TypeChecker<'a> {
+    pub fn new(error_handler: &mut ErrorHandler) -> TypeChecker {
         TypeChecker { err: error_handler }
     }
 

--- a/src/wasm/mir_to_wasm.rs
+++ b/src/wasm/mir_to_wasm.rs
@@ -32,7 +32,7 @@ struct LocalState<'a> {
 }
 
 impl<'a> LocalState<'a> {
-    pub fn new(global_state: &'a GlobalState) -> LocalState<'a> {
+    pub fn new(global_state: &GlobalState) -> LocalState {
         LocalState {
             locals: HashMap::new(),
             blocks: HashMap::new(),
@@ -58,12 +58,12 @@ impl<'a> LocalState<'a> {
     }
 }
 
-pub struct Compiler<'a, 'b> {
-    err: &'b mut ErrorHandler<'a>,
+pub struct Compiler<'a> {
+    err: &'a mut ErrorHandler,
 }
 
-impl<'a, 'b> Compiler<'a, 'b> {
-    pub fn new(error_handler: &'b mut ErrorHandler<'a>) -> Compiler<'a, 'b> {
+impl<'a> Compiler<'a> {
+    pub fn new(error_handler: &mut ErrorHandler) -> Compiler {
         Compiler { err: error_handler }
     }
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -6,9 +6,9 @@ mod opcode;
 mod sections;
 mod wasm;
 
-pub fn to_wasm<'a, 'b>(
+pub fn to_wasm<'a>(
     mir_program: mir::Program,
-    error_handler: &'b mut ErrorHandler<'a>,
+    error_handler: &'a mut ErrorHandler,
 ) -> Vec<u8> {
     println!("\n/// Compiling ///\n");
 

--- a/test/add.frk
+++ b/test/add.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/call.frk
+++ b/test/call.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/else.frk
+++ b/test/else.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/expose.frk
+++ b/test/expose.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 // Test the expose keyword
 expose main as _start

--- a/test/identifiers.frk
+++ b/test/identifiers.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/if.frk
+++ b/test/if.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/integration_exp.frk
+++ b/test/integration_exp.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/integration_fact.frk
+++ b/test/integration_fact.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/let.frk
+++ b/test/let.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/package.frk
+++ b/test/package.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/return.frk
+++ b/test/return.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/unegation.frk
+++ b/test/unegation.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 

--- a/test/use.frk
+++ b/test/use.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 // Test the use keyword
 use "std/awesome"

--- a/test/while.frk
+++ b/test/while.frk
@@ -1,4 +1,4 @@
-package "test"
+package "#test"
 
 expose main as _start
 


### PR DESCRIPTION
Fixes  #40, part of the architecture refactoring effort #23.

**Achitectural changes**
- Introduce a Driver struct to orchestrate compilation.
- ErrorHandler now takes ownership of files

**New features**
- Accept either a file or a directory as input.
- If the input is a file and a is a single file package or an orphan file, it will be compiled alone.
- If the input is a file and belongs to a package, the whole directory is scanned to look for other files of that package.
- If the input is a directory, it is scanned to look for files belonging to a package.