### PR TITLE
Expose types of pub declarations in mir::Program - fix #47

### DIFF
--- a/src/mir/ast_to_mir.rs
+++ b/src/mir/ast_to_mir.rs
@@ -57,7 +57,7 @@ impl<'a> MIRProducer<'a> {
             }
         }
 
-        Program { funs: funs }
+        Program { funs: funs, pub_types: prog.pub_types }
     }
 
     fn reduce_fun(&mut self, fun: NameFun, s: &mut State) -> Result<Function, String> {

--- a/src/mir/mir.rs
+++ b/src/mir/mir.rs
@@ -1,9 +1,12 @@
 #![allow(dead_code)] // Call::Indirect, Value::F32, Value::F64
+use super::types::Type as ASTType;
 
 use std::fmt;
+use std::collections::HashMap;
 
 pub struct Program {
     pub funs: Vec<Function>,
+    pub pub_types: HashMap<String, ASTType>
 }
 
 pub struct Function {

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -4,8 +4,10 @@ use crate::error::ErrorHandler;
 use self::names::{NameStore, ResolvedProgram};
 use self::types::TypeStore;
 
+use std::collections::HashMap;
+
 pub use self::names::NameId;
-pub use self::types::TypeId;
+pub use self::types::{TypeId, Type as ASTType};
 pub use mir::*;
 
 mod ast_to_mir;
@@ -19,6 +21,7 @@ pub struct TypedProgram {
     pub funs: Vec<names::Function>,
     pub names: NameStore,
     pub types: TypeStore,
+    pub pub_types: HashMap<String, ASTType>
 }
 
 pub use mir::Program;

--- a/src/mir/names.rs
+++ b/src/mir/names.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 pub type NameId = usize;
 
+/// A type program, ready to be converted to MIR.
 pub struct ResolvedProgram {
     pub funs: Vec<Function>,
     pub names: NameStore,

--- a/src/mir/resolver.rs
+++ b/src/mir/resolver.rs
@@ -586,7 +586,7 @@ impl<'a> NameResolver<'a> {
         }
     }
 
-    // must be called first to bring all global function declarations in scope
+    /// Register top level functions into the global state (`state`).
     fn register_functions(&mut self, funs: &Vec<ast::Function>, state: &mut State) {
         for fun in funs {
             let mut params = Vec::new();


### PR DESCRIPTION
Fixes #47

Expose type of pub declarations in prevision of package imports.